### PR TITLE
Show reactive variables as well as data context

### DIFF
--- a/temple.js
+++ b/temple.js
@@ -100,7 +100,14 @@ Template.body.events({
 
       if (target.length && !$(target).closest('#Constellation').length) {
         if (!Temple.dict.get('Temple_freeze_data') || evt.type === 'click') {
-          Temple.dict.set('Temple_current_context', Blaze.getData(target[0]));
+          let data = Blaze.getData(target[0]);
+          let template = Blaze.getView(target[0]).templateInstance();
+          Object.keys(template).forEach( t => {
+            if(template[t] instanceof ReactiveVar){
+              data[`RV_${t}`] = template[t].get();
+            }
+          })
+          Temple.dict.set('Temple_current_context', data);
           if (!!Constellation && Constellation.tabVisible('temple','plugin')) {
             // Change the breadcrumbs
             Temple.makeBreadcrumbs(target);


### PR DESCRIPTION
Hi and thanks for the great package. We often find ourselves wanting to inspect not just the data context of a template, but also the state of its reactive variables. This PR checks the template for reactive variables and shows them next to the data context. I am sure the presentation can be improved, and we can also show reactive dicts, but I wanted to see it anyone is interested in that before we do the work. Thanks